### PR TITLE
Feature/remember volume

### DIFF
--- a/src/components/PlayerControls.tsx
+++ b/src/components/PlayerControls.tsx
@@ -9,6 +9,7 @@ import { Button, Col, Layout, Row, Slider, Space, Typography } from 'antd';
 import { FC, useRef, useState } from 'react';
 import { TrackResponse } from '../apis/dtos';
 import { secondsToString } from '../utils/string';
+import { saveVolume } from '../utils/volume';
 import './PlayerControls.less';
 
 interface Props {
@@ -132,6 +133,7 @@ const PlayerControls: FC<Props> = ({
                 value={volume.value}
                 tooltipVisible={false}
                 onChange={volume.onChange}
+                onAfterChange={saveVolume}
               />
             </div>
           </Col>

--- a/src/containers/DigestContainer.tsx
+++ b/src/containers/DigestContainer.tsx
@@ -16,6 +16,7 @@ import {
 import { trackSourceProviderMap } from '../constants';
 import { usePlayer } from '../hooks';
 import { TrackSourceProvider } from '../types';
+import { getInitialVolume } from '../utils/volume';
 
 // TODO: debugging purpose only
 const disableNativeControl = false;
@@ -42,7 +43,7 @@ const DigestContainer: FC<Props> = ({ id }) => {
     stopOthers,
     volume,
     changeVolume,
-  } = usePlayer();
+  } = usePlayer(getInitialVolume());
 
   const youtubePlayer = useRef<ReactPlayer | null>(null);
   const soundcloudPlayer = useRef<ReactPlayer | null>(null);

--- a/src/containers/DigestContainer.tsx
+++ b/src/containers/DigestContainer.tsx
@@ -43,7 +43,7 @@ const DigestContainer: FC<Props> = ({ id }) => {
     stopOthers,
     volume,
     changeVolume,
-  } = usePlayer(getInitialVolume());
+  } = usePlayer({ initialVolume: getInitialVolume() });
 
   const youtubePlayer = useRef<ReactPlayer | null>(null);
   const soundcloudPlayer = useRef<ReactPlayer | null>(null);

--- a/src/containers/RadioContainer.tsx
+++ b/src/containers/RadioContainer.tsx
@@ -45,7 +45,7 @@ const RadioContainer: FC<Props> = ({ roomName }) => {
     stopOthers,
     volume,
     changeVolume,
-  } = usePlayer(getInitialVolume());
+  } = usePlayer({ initialVolume: getInitialVolume() });
 
   const youtubePlayer = useRef<ReactPlayer | null>(null);
   const soundcloudPlayer = useRef<ReactPlayer | null>(null);

--- a/src/containers/RadioContainer.tsx
+++ b/src/containers/RadioContainer.tsx
@@ -14,6 +14,7 @@ import {
 import { trackSourceProviderMap } from '../constants';
 import { usePlayer } from '../hooks';
 import { TrackSourceProvider } from '../types';
+import { getInitialVolume } from '../utils/volume';
 
 const socket = io(`${process.env.REACT_APP_API_BASE_URL}/radios/main`, {
   transports: ['websocket'],
@@ -44,7 +45,7 @@ const RadioContainer: FC<Props> = ({ roomName }) => {
     stopOthers,
     volume,
     changeVolume,
-  } = usePlayer();
+  } = usePlayer(getInitialVolume());
 
   const youtubePlayer = useRef<ReactPlayer | null>(null);
   const soundcloudPlayer = useRef<ReactPlayer | null>(null);

--- a/src/hooks/usePlayer.tsx
+++ b/src/hooks/usePlayer.tsx
@@ -44,7 +44,7 @@ interface PlayActions {
 
 export interface PlayerHookProps extends PlayerState, PlayActions {}
 
-export const usePlayer = (): PlayerHookProps => {
+export const usePlayer = (initialVolume: number = 100): PlayerHookProps => {
   const initialProviderState = {
     ref: null,
     track: null,
@@ -61,7 +61,7 @@ export const usePlayer = (): PlayerHookProps => {
       [TrackSourceProvider.SOUNDCLOUD]: initialProviderState,
     },
     currentProvider: null,
-    volume: 100,
+    volume: initialVolume,
     loading: false,
   });
 

--- a/src/hooks/usePlayer.tsx
+++ b/src/hooks/usePlayer.tsx
@@ -44,7 +44,12 @@ interface PlayActions {
 
 export interface PlayerHookProps extends PlayerState, PlayActions {}
 
-export const usePlayer = (initialVolume: number = 100): PlayerHookProps => {
+export interface PlayerHookOptions {
+  initialVolume?: number;
+}
+
+export const usePlayer = (options?: PlayerHookOptions): PlayerHookProps => {
+  const initialVolume = options?.initialVolume ?? 100;
   const initialProviderState = {
     ref: null,
     track: null,

--- a/src/utils/volume.ts
+++ b/src/utils/volume.ts
@@ -1,6 +1,7 @@
 export const getInitialVolume = () => {
   const volume = localStorage.getItem('volume');
   return (volume && Number.parseInt(volume, 10)) || 100;
-}
+};
 
-export const saveVolume = (value: number) => localStorage.setItem('volume', value.toString());
+export const saveVolume = (value: number) =>
+  localStorage.setItem('volume', value.toString());

--- a/src/utils/volume.ts
+++ b/src/utils/volume.ts
@@ -1,0 +1,6 @@
+export const getInitialVolume = () => {
+  const volume = localStorage.getItem('volume');
+  return (volume && Number.parseInt(volume, 10)) || 100;
+}
+
+export const saveVolume = (value: number) => localStorage.setItem('volume', value.toString());


### PR DESCRIPTION
플레이어의 볼륨을 기억하는 기능을 추가했습니다
* 볼륨 슬라이더의 mouseup 이벤트 핸들러(Slider.onAfterChange)가 localStorage에 값을 저장합니다
* 페이지 최초 진입시 localStorage에서 이전 볼륨 값 불러오기를 시도합니다

제 로컬에서 테스트가 어려운 관계로(..) Josh께서 여유로우실 때 테스트 한번 부탁드립니다 🙏 